### PR TITLE
Investigate lambda function error

### DIFF
--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -352,6 +352,11 @@ func handleCreateProject(ctx context.Context, request events.APIGatewayProxyRequ
 	// Set environment variables for the Nobl9 SDK
 	os.Setenv("NOBL9_SDK_CLIENT_ID", credentials.ClientID)
 	os.Setenv("NOBL9_SDK_CLIENT_SECRET", credentials.ClientSecret)
+	
+	// Fix for Lambda: Set HOME to /tmp to avoid "HOME is not defined" error
+	// The Nobl9 SDK tries to access the HOME directory for config/cache files
+	// but in Lambda, $HOME points to a non-existent read-only directory
+	os.Setenv("HOME", "/tmp")
 
 	// Create a context with timeout for all SDK operations
 	sdkCtx, cancel := context.WithTimeout(ctx, 60*time.Second)


### PR DESCRIPTION
Set `HOME` environment variable to `/tmp` to resolve Nobl9 SDK initialization error in AWS Lambda.

In AWS Lambda, the default `$HOME` directory (`/home/sbx_user1051`) is non-existent and read-only. The Nobl9 SDK's `DefaultClient()` function attempts to access `$HOME` for configuration, leading to an error. Setting `HOME` to `/tmp` provides a writable location for the SDK.

---
<a href="https://cursor.com/background-agent?bcId=bc-423f684f-1df2-4fdc-a5a5-3b4bae9a7523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-423f684f-1df2-4fdc-a5a5-3b4bae9a7523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

